### PR TITLE
✨[PR]2025/02/28 관리자 페이지 탈퇴자에서 유저로 권한 변경 - 김규남✨

### DIFF
--- a/funniture-fe/src/apis/AdminAPI.js
+++ b/funniture-fe/src/apis/AdminAPI.js
@@ -17,6 +17,7 @@ export const callUserListByAdminAPI = async (setUserList) => {
     }
 };
 
+// 관리자 페이지의 제공자 정보 들고오는 애
 export const callOwnerListByAdminAPI = async (setOwnerList) => {
     const requestURL = `http://localhost:8080/api/v1/admin/ownerList`;
     try {
@@ -50,6 +51,7 @@ export const callConvertByAdminAPI = async (setConvertList) => {
     }
 }
 
+// 관리자 페이지에 모달에 들어갈 데이터 (수정해야 함)
 export const callConvertAppAPI = async () => {
     const requestURL = `http://localhost:8080/api/v1/admin/convertApp/modal`;
 
@@ -65,6 +67,31 @@ export const callConvertAppAPI = async () => {
 };
 
 
-export const callLeaverUserByAdminAPI = () => {
+export const callLeaverUserByAdminAPI = async (setLeaverUserList) => {
+    const requestURL = `http://localhost:8080/api/v1/admin/leaverList`
+    try {
+        const response = await api.get(requestURL);
 
+        console.log('관리자 페이지 전체 탈퇴자 정보 요청 서버에 잘 다녀왔나? response : ', response);
+
+        // 서버에서 받은 데이터를 userList 상태에 저장
+        if (response.data) {
+            setLeaverUserList(response.data.results.result);
+        }
+    } catch (error) {
+        console.error('API 호출 중 오류 발생:', error);
+    }
+}
+
+// 관리자 페이지 탈퇴자 목록에서 접근 권한 변경을 유저로 승인 했을 때 동작
+export const callChangeUserRoleAPI = async (userIds) => {
+    const requestURL = `http://localhost:8080/api/v1/admin/reactivate`
+    try {
+        const response = await api.post(requestURL, userIds );
+
+        console.log('관리자 페이지 전체 탈퇴자 정보 요청 서버에 잘 다녀왔나? response : ', response);
+
+    } catch (error) {
+        console.error('API 호출 중 오류 발생:', error);
+    }
 }

--- a/funniture-fe/src/pages/admin/AdminLeaver.js
+++ b/funniture-fe/src/pages/admin/AdminLeaver.js
@@ -2,8 +2,9 @@ import AdminTop from '../../component/adminpage/AdminTop';
 import RentalCss from './rental.module.css';
 import { useState, useEffect } from 'react';
 import Pagination from '../../component/Pagination';
-import { callLeaverUserByAdminAPI } from '../../apis/AdminAPI';
+import { callLeaverUserByAdminAPI , callChangeUserRoleAPI } from '../../apis/AdminAPI';
 import { useNavigate } from 'react-router-dom';
+import BtnModal from '../../component/BtnModal';
 
 function AdminLeaver() {
 
@@ -11,12 +12,52 @@ function AdminLeaver() {
 
     // 회원 정보 리스트를 저장할 상태
     const [leaverUserList, setLeaverUserList] = useState([]); // 여러 제공자 정보를 저장하는 배열
+    const [selectedUsers, setSelectedUsers] = useState([]); // 체크박스 관리
+    const [showModal, setShowModal] = useState(false); // 접근 권한 변경 누를 때 뜨는 모달 
 
     useEffect(() => {
         console.log('관리자 페이지, 제공자 useEffect 실행');
         callLeaverUserByAdminAPI(setLeaverUserList);
     }, []);
 
+    // 체크박스 변경 핸들러
+    const handleCheckboxChange = (memberId) => {
+        setSelectedUsers((prevSelectedUsers) => {
+            if (prevSelectedUsers.includes(memberId)) {
+                // 이미 선택된 경우 제거
+                return prevSelectedUsers.filter((id) => id !== memberId);
+            } else {
+                // 선택되지 않은 경우 추가
+                return [...prevSelectedUsers, memberId];
+            }
+        });
+    };
+
+    const handleAccessChangeClick = () => {
+        if (selectedUsers.length === 0) {
+            alert('변경할 사용자를 선택해주세요.');
+            return;
+        }
+        setShowModal(true); // 모달 열기
+    };
+
+    const handleConfirmAccessChange = async () => {
+        try {
+            await callChangeUserRoleAPI(selectedUsers); // 권한 변경 API 호출
+            alert('권한이 변경되었습니다.');
+    
+            // 데이터 갱신
+            callLeaverUserByAdminAPI(setLeaverUserList);
+    
+            setSelectedUsers([]); // 선택 초기화
+            setShowModal(false);  // 모달 닫기
+        } catch (error) {
+            console.error(error);
+            alert('권한 변경에 실패했습니다.');
+        }
+    };
+    
+    
 
     return (
         <>
@@ -29,12 +70,13 @@ function AdminLeaver() {
                         <button onClick={()=>{navigate('/admin/authority/owner')}}>제공자</button>
                         <button onClick={()=>{navigate('/admin/authority/convert')}}>전환요청</button>
                         <button onClick={()=>{navigate('/admin/authority/leaver')}}>탈퇴자</button>
-                        <button>접근권한변경</button>
+                        <button onClick={handleAccessChangeClick}>접근권한변경</button>
                     </div>
                     <div className={RentalCss.rentalBox}>
                         <div className={RentalCss.rentalSubBox}>
                             {/* 테이블 헤더 */}
                             <div className={RentalCss.title}>
+                                <div style={{ width: "3%" }}><input type="checkbox" /></div>
                                 <div style={{ width: "15%" }}><p>회원번호</p></div>
                                 <div style={{ width: "10%" }}><p>이름</p></div>
                                 <div style={{ width: "20%" }}><p>전화번호</p></div>
@@ -53,6 +95,10 @@ function AdminLeaver() {
                                 // 데이터가 있을 경우 렌더링
                                 leaverUserList.map((leaver) => (
                                     <div key={leaverUserList.memberId} className={RentalCss.rentalItems}>
+                                        <div style={{ width: "3%" }}>
+                                            <input type="checkbox"
+                                                   checked={selectedUsers.includes(leaver.memberId)}
+                                                   onChange={() => handleCheckboxChange(leaver.memberId)}/></div>
                                         <div style={{ width: '15%' }}><p>{leaver.memberId}</p></div>
                                         <div style={{ width: '10%' }}><p>{leaver.userName}</p></div>
                                         <div style={{ width: '20%' }}><p>{leaver.phoneNumber}</p></div>
@@ -67,6 +113,18 @@ function AdminLeaver() {
                         {/* 페이지네이션 컴포넌트 */}
                         <Pagination />
                     </div>
+
+                    <BtnModal
+                    showBtnModal={showModal}
+                    setShowBtnModal={setShowModal}
+                    modalTitle="접근 권한 변경"
+                    modalContext="선택된 사용자의 권한을 일반 회원으로 변경하시겠습니까?"
+                    btnText="예"
+                    secondBtnText="취소"
+                    onSuccess={handleConfirmAccessChange}
+                    onFail={() => setShowModal(false)}
+                    />
+
             </div>
         </>
     )


### PR DESCRIPTION
## #️⃣ Issue Number

#194 

## 📝 요약(Summary)

- 관리자 페이지에서 탈퇴자 회원 불러오기
- 탈퇴한 회원 선택하여 접근권한 변경 클릭 시, 유저로 변경
- 변경됨과 동시에 유저 항목으로 데이터 이동

## 🎨 프론트엔드 PR 유형
### ✨ 기능 및 UI  
- [x] 새로운 기능 추가  
- [ ] 스타일 및 UI 디자인 변경  
- [ ] React 컴포넌트 리팩토링 (컴포넌트 분리, Props 구조 변경, 재사용성 개선)
- [ ] 라우팅 관련 수정 (React Router 추가/삭제, 네비게이션 로직 변경)

### 🛠️ 상태 및 성능    
- [ ] React 상태 관리 관련 변경 (Redux, Context API)  
- [ ] React 훅 관련 수정 (`useEffect` 최적화, 의존성 배열 수정)  
- [ ] React 성능 최적화 (`memo`, `useMemo`, `useCallback` 활용)
- [ ] API 연동 및 데이터 페칭 수정 (Axios, Fetch)

### 😈 버그  
- [ ] 버그 수정

### 🎸 기타  
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제
- [ ] 주석 추가 및 수정  
- [ ] 테스트 코드 추가 및 수정
- [ ] 기타

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/14c9d9d4-8ab4-47e1-b6e4-c44033de5fee)


## ✅ PR Checklist
📢 merge 할 분 이름에 체크해주세요.
- [ ] 김규남
- [ ] 김경훈
- [ ] 박재민
- [ ] 정예진
- [x] 정은미

